### PR TITLE
feat: support editing clothing items

### DIFF
--- a/WardrobeManager/Features/Wardrobe/AddClothingView.swift
+++ b/WardrobeManager/Features/Wardrobe/AddClothingView.swift
@@ -3,10 +3,34 @@ import SwiftData
 import UIKit
 
 struct AddClothingView: View {
+    enum Mode {
+        case add
+        case edit(ClothingItem)
+
+        var title: String {
+            switch self {
+            case .add:
+                return "添加衣物"
+            case .edit:
+                return "编辑衣物"
+            }
+        }
+
+        var saveButtonTitle: String {
+            switch self {
+            case .add:
+                return "保存"
+            case .edit:
+                return "更新"
+            }
+        }
+    }
+
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(AppContainer.self) private var appContainer
 
+    private let mode: Mode
     @State private var name = ""
     @State private var category: ClothingCategory = .top
     @State private var color = ""
@@ -30,6 +54,41 @@ struct AddClothingView: View {
         !style.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !location.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         selectedImageData != nil
+    }
+
+    init(mode: Mode = .add) {
+        self.mode = mode
+
+        switch mode {
+        case .add:
+            _name = State(initialValue: "")
+            _category = State(initialValue: .top)
+            _color = State(initialValue: "")
+            _style = State(initialValue: "")
+            _location = State(initialValue: "")
+            _season = State(initialValue: .allSeason)
+            _tagsText = State(initialValue: "")
+            _purchasePriceText = State(initialValue: "")
+            _rawImage = State(initialValue: nil)
+            _processedImageData = State(initialValue: nil)
+            _selectedImageVersion = State(initialValue: .original)
+        case let .edit(item):
+            _name = State(initialValue: item.name)
+            _category = State(initialValue: item.category)
+            _color = State(initialValue: item.color)
+            _style = State(initialValue: item.style)
+            _location = State(initialValue: item.location)
+            _season = State(initialValue: item.season)
+            _tagsText = State(initialValue: item.tags.joined(separator: ", "))
+            if let purchasePrice = item.purchasePrice {
+                _purchasePriceText = State(initialValue: String(purchasePrice))
+            } else {
+                _purchasePriceText = State(initialValue: "")
+            }
+            _rawImage = State(initialValue: UIImage(data: item.imageData))
+            _processedImageData = State(initialValue: nil)
+            _selectedImageVersion = State(initialValue: .original)
+        }
     }
 
     var body: some View {
@@ -97,7 +156,7 @@ struct AddClothingView: View {
                     .keyboardType(.decimalPad)
             }
         }
-        .navigationTitle("添加衣物")
+        .navigationTitle(mode.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -107,7 +166,7 @@ struct AddClothingView: View {
             }
 
             ToolbarItem(placement: .topBarTrailing) {
-                Button("保存") {
+                Button(mode.saveButtonTitle) {
                     saveItem()
                 }
                 .disabled(!canSave)
@@ -211,22 +270,37 @@ struct AddClothingView: View {
     private func saveItem() {
         guard let selectedImageData else { return }
 
-        let item = ClothingItem(
-            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
-            category: category,
-            color: color.trimmingCharacters(in: .whitespacesAndNewlines),
-            style: style.trimmingCharacters(in: .whitespacesAndNewlines),
-            location: location.trimmingCharacters(in: .whitespacesAndNewlines),
-            imageData: selectedImageData,
-            tags: tagsText
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty },
-            season: season,
-            purchasePrice: Double(purchasePriceText)
-        )
+        let tags = tagsText
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
 
-        modelContext.insert(item)
+        switch mode {
+        case .add:
+            let item = ClothingItem(
+                name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                category: category,
+                color: color.trimmingCharacters(in: .whitespacesAndNewlines),
+                style: style.trimmingCharacters(in: .whitespacesAndNewlines),
+                location: location.trimmingCharacters(in: .whitespacesAndNewlines),
+                imageData: selectedImageData,
+                tags: tags,
+                season: season,
+                purchasePrice: Double(purchasePriceText)
+            )
+
+            modelContext.insert(item)
+        case let .edit(item):
+            item.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            item.category = category
+            item.color = color.trimmingCharacters(in: .whitespacesAndNewlines)
+            item.style = style.trimmingCharacters(in: .whitespacesAndNewlines)
+            item.location = location.trimmingCharacters(in: .whitespacesAndNewlines)
+            item.imageData = selectedImageData
+            item.tags = tags
+            item.season = season
+            item.purchasePrice = Double(purchasePriceText)
+        }
 
         do {
             try modelContext.save()

--- a/WardrobeManager/Features/Wardrobe/ClothingDetailView.swift
+++ b/WardrobeManager/Features/Wardrobe/ClothingDetailView.swift
@@ -5,6 +5,7 @@ struct ClothingDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     let item: ClothingItem
+    @State private var isPresentingEditSheet = false
     @State private var isShowingDeleteConfirmation = false
 
     var body: some View {
@@ -26,6 +27,11 @@ struct ClothingDetailView: View {
             Button("取消", role: .cancel) {}
         } message: {
             Text("删除后无法恢复。")
+        }
+        .sheet(isPresented: $isPresentingEditSheet) {
+            NavigationStack {
+                AddClothingView(mode: .edit(item))
+            }
         }
     }
 
@@ -57,6 +63,11 @@ struct ClothingDetailView: View {
     private var actionSection: some View {
         SectionCard(title: "操作") {
             VStack(spacing: 12) {
+                Button("编辑信息") {
+                    isPresentingEditSheet = true
+                }
+                .buttonStyle(.bordered)
+
                 Button("今天穿了") {
                     item.lastWornDate = .now
                     item.wearCount += 1


### PR DESCRIPTION
## Summary
- add an edit mode to the clothing form so existing items can be updated in place
- add an edit entry point from the clothing detail screen
- preserve existing delete and mark-as-worn flows while saving edits back to list/detail views

## Verification
- xcodebuild build -scheme WardrobeManager -project WardrobeManager.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'
- xcodebuild test -scheme WardrobeManager -project WardrobeManager.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17' *(fails before running tests because the existing `WardrobeManagerTests` target has no Info.plist / GENERATE_INFOPLIST_FILE setup)*

Closes #2