### PR TITLE
feat: unify operation feedback

### DIFF
--- a/WardrobeManager/App/AppContainer.swift
+++ b/WardrobeManager/App/AppContainer.swift
@@ -4,13 +4,42 @@ import Observation
 @Observable
 final class AppContainer {
     var selectedTab: AppTab = .wardrobe
+    var operationFeedback: OperationFeedback?
     let imageProcessor = ClothingImageProcessor()
     let previewComposer = OutfitPreviewComposer()
     let scorer = OutfitScorer()
+
+    @ObservationIgnored private var feedbackDismissTask: Task<Void, Never>?
+
+    func showOperationFeedback(_ feedback: OperationFeedback, autoDismissAfter delayNanoseconds: UInt64 = 2_000_000_000) {
+        feedbackDismissTask?.cancel()
+        operationFeedback = feedback
+
+        feedbackDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.operationFeedback = nil
+        }
+    }
+
+    func hideOperationFeedback() {
+        feedbackDismissTask?.cancel()
+        operationFeedback = nil
+    }
 }
 
 enum AppTab: Hashable {
     case wardrobe
     case outfit
     case history
+}
+
+struct OperationFeedback: Equatable {
+    enum Style {
+        case success
+        case error
+    }
+
+    var message: String
+    var style: Style
 }

--- a/WardrobeManager/App/RootTabView.swift
+++ b/WardrobeManager/App/RootTabView.swift
@@ -33,5 +33,48 @@ struct RootTabView: View {
             .tag(AppTab.history)
         }
         .tint(.accentColor)
+        .overlay(alignment: .top) {
+            if let feedback = appContainer.operationFeedback {
+                OperationFeedbackBanner(feedback: feedback)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .onTapGesture {
+                        appContainer.hideOperationFeedback()
+                    }
+            }
+        }
+        .animation(.smooth, value: appContainer.operationFeedback)
+    }
+}
+
+private struct OperationFeedbackBanner: View {
+    let feedback: OperationFeedback
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: feedback.style == .success ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.subheadline.weight(.bold))
+
+            Text(feedback.message)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(2)
+
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(backgroundColor, in: Capsule())
+        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+    }
+
+    private var backgroundColor: Color {
+        switch feedback.style {
+        case .success:
+            return Color.green.opacity(0.95)
+        case .error:
+            return Color.red.opacity(0.95)
+        }
     }
 }

--- a/WardrobeManager/Features/Outfit/OutfitBuilderView.swift
+++ b/WardrobeManager/Features/Outfit/OutfitBuilderView.swift
@@ -12,7 +12,6 @@ struct OutfitBuilderView: View {
     @State private var shoesItem: ClothingItem?
     @State private var accessoryItem: ClothingItem?
     @State private var pickerCategory: ClothingCategory?
-    @State private var savedMessageVisible = false
     @State private var generatedPreviewImageData: Data?
     @State private var generatedScore: OutfitScore?
     @State private var editableScore = 0
@@ -52,19 +51,6 @@ struct OutfitBuilderView: View {
                 )
             }
         }
-        .overlay(alignment: .top) {
-            if savedMessageVisible {
-                Text("搜配记录已保存")
-                    .font(.subheadline.weight(.semibold))
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
-                    .background(Color.green.opacity(0.92), in: Capsule())
-                    .foregroundStyle(.white)
-                    .padding(.top, 12)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-            }
-        }
-        .animation(.smooth, value: savedMessageVisible)
         .onChange(of: selectedItems.map(\.id)) { _, _ in
             generatedPreviewImageData = nil
             generatedScore = nil
@@ -295,20 +281,14 @@ struct OutfitBuilderView: View {
 
         do {
             try modelContext.save()
-            withAnimation {
-                savedMessageVisible = true
-            }
-
-            Task {
-                try? await Task.sleep(for: .seconds(1.5))
-                await MainActor.run {
-                    withAnimation {
-                        savedMessageVisible = false
-                    }
-                }
-            }
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: "搜配记录已保存", style: .success)
+            )
         } catch {
-            assertionFailure("Failed to save outfit: \(error)")
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: "搜配记录保存失败，请稍后再试。", style: .error),
+                autoDismissAfter: 3_000_000_000
+            )
         }
     }
 

--- a/WardrobeManager/Features/Wardrobe/AddClothingView.swift
+++ b/WardrobeManager/Features/Wardrobe/AddClothingView.swift
@@ -230,9 +230,17 @@ struct AddClothingView: View {
 
         do {
             try modelContext.save()
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: "衣物已保存", style: .success)
+            )
             dismiss()
         } catch {
-            errorMessage = "衣物保存失败，请稍后再试。"
+            let message = "衣物保存失败，请稍后再试。"
+            errorMessage = message
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: message, style: .error),
+                autoDismissAfter: 3_000_000_000
+            )
         }
     }
 }

--- a/WardrobeManager/Features/Wardrobe/ClothingDetailView.swift
+++ b/WardrobeManager/Features/Wardrobe/ClothingDetailView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct ClothingDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppContainer.self) private var appContainer
     let item: ClothingItem
     @State private var isShowingDeleteConfirmation = false
 
@@ -58,14 +59,26 @@ struct ClothingDetailView: View {
         SectionCard(title: "操作") {
             VStack(spacing: 12) {
                 Button("今天穿了") {
+                    let previousLastWornDate = item.lastWornDate
+                    let previousWearCount = item.wearCount
                     item.lastWornDate = .now
                     item.wearCount += 1
 
                     do {
                         try modelContext.save()
                     } catch {
-                        assertionFailure("Failed to save wear record: \(error)")
+                        item.lastWornDate = previousLastWornDate
+                        item.wearCount = previousWearCount
+                        appContainer.showOperationFeedback(
+                            OperationFeedback(message: "穿着记录保存失败，请稍后再试。", style: .error),
+                            autoDismissAfter: 3_000_000_000
+                        )
+                        return
                     }
+
+                    appContainer.showOperationFeedback(
+                        OperationFeedback(message: "已记录今天穿了这件单品", style: .success)
+                    )
                 }
                 .buttonStyle(.borderedProminent)
 
@@ -82,9 +95,16 @@ struct ClothingDetailView: View {
 
         do {
             try modelContext.save()
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: "衣物已删除", style: .success)
+            )
             dismiss()
         } catch {
-            assertionFailure("Failed to delete clothing item: \(error)")
+            modelContext.rollback()
+            appContainer.showOperationFeedback(
+                OperationFeedback(message: "删除失败，请稍后再试。", style: .error),
+                autoDismissAfter: 3_000_000_000
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- add a lightweight global feedback banner rendered from the root tab container
- route key wardrobe and outfit actions through shared success / failure feedback
- replace assertion-only failure handling with user-visible messaging and rollback where needed

## Verification
- xcodebuild build -scheme WardrobeManager -project WardrobeManager.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'

Closes #5